### PR TITLE
Fix run.sh to override config with environment in Kibana 4.3.0

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,11 +6,11 @@ KIBANA_CONF_FILE="/opt/kibana-${KIBANA_VERSION}/config/kibana.yml"
 
 KIBANA_ES_URL=${KIBANA_ES_URL:-http://elasticsearch:9200}
 
-sed -i "s;^elasticsearch_url:.*;elasticsearch_url: ${KIBANA_ES_URL};" "${KIBANA_CONF_FILE}"
+sed -i "s;.*elasticsearch\.url:.*;elasticsearch\.url: ${KIBANA_ES_URL};" "${KIBANA_CONF_FILE}"
 
 if [ -n "${KIBANA_INDEX}" ]; then
     echo "setting index!"
-    sed -i "s;^kibana_index:.*;kibana_index: ${KIBANA_INDEX};" "${KIBANA_CONF_FILE}"
+    sed -i "s;.*kibana\.index:.*;kibana\.index: ${KIBANA_INDEX};" "${KIBANA_CONF_FILE}"
 fi
 
 # mesos-friendly change


### PR DESCRIPTION
Updated in light of:
https://www.elastic.co/guide/en/kibana/current/kibana-server-properties.html

Using:
https://github.com/pires/kubernetes-elasticsearch-cluster

Gets a green status with the included changes. 
